### PR TITLE
Added readdir support. Implements #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Make a new instance. Options include:
   write: fn, // sets ._write
   del: fn, // sets ._del
   stat: fn, // sets ._stat
+  readdir: fn, // sets ._readdir
   close: fn, // sets ._close
   destroy: fn // sets ._destroy
 }
@@ -89,6 +90,10 @@ True if the storage implements `._del`.
 #### `storage.statable`
 
 True if the storage implements `._stat`.
+
+#### `storage.canReaddir`
+
+True if the storage implements `._readdir`.
 
 #### `storage.opened`
 
@@ -202,6 +207,18 @@ Stat the storage. Should return an object with useful information about the unde
 Implement storage stat.
 
 Call `req.callback(err, statObject)` when the stat has completed.
+
+Note that this is guaranteed to run after the storage has been opened and not after it has been closed.
+
+#### `storage.readdir(callback)`
+
+Read the storage directory information. Should return an array with strings of child paths.
+
+#### `storage._readdir(req)`
+
+Implement storage readdir.
+
+Call `req.callback(err, listItems)` when the readdir has completed.
 
 Note that this is guaranteed to run after the storage has been opened and not after it has been closed.
 

--- a/test.js
+++ b/test.js
@@ -436,3 +436,26 @@ tape('open error forwarded to dependents', function (t) {
     t.end()
   })
 })
+
+tape('readdir on path', function (t) {
+  var s = ras({
+    readdir: req => req.callback(null, [ 'hello' ])
+  })
+
+  s.readdir((err, paths) => {
+    t.error(err)
+    t.same(paths[0], 'hello')
+    t.end()
+  })
+})
+
+tape('readdir error propagation', function (t) {
+  var s = ras({
+    readdir: req => req.callback(new Error('readdir error'))
+  })
+
+  s.readdir((err) => {
+    t.same(err.message, 'readdir error')
+    t.end()
+  })
+})


### PR DESCRIPTION
For a test I experimented with implementing #3 - list API - as `.readdir` support for random-access-storage. _(I called it more unixy "readdir" instead of list)_ It works and does feel reasonable, however, a few caveats before I think should be merged.

Please comment with suggestions on how to proceed.

1. Most _random-access-*_ packages can stay as they are with this PR, but `random-access-latency` and `random-access-pause-wrapper` **need** also to be updated, as these are general purpose wrappers.
2. `random-access-test` _should_ also to be prepared to support _readdir_. Else we can't test it.
3. _(the big one)_ ↓

The propagated and practiced use of`random-access-memory` is at odds with `.readdir`.
Two `ram()` instances share no existing universe, but with most other implementations (like `raf()`), multiple instances essentially share the same universe.

Now I am wondering if it might be a good idea to **Semver major** change `ram` to support `.readdir` and also allow for shared universes:

```javascript
const ram = require('random-access-memory')
const myRam = ram()

myRam('a').write('file.txt', 'hello', () => {
   myRam().readdir((entries) => {
      console.log(entries) // ['file.txt']
   })
})
```

it may need something like `myRam.close()`.
