### PR TITLE
Use constants instead of numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,17 @@ var NOT_DELETABLE = defaultImpl(new Error('Not deletable'))
 var NOT_STATABLE = defaultImpl(new Error('Not statable'))
 var NO_OPEN_READABLE = defaultImpl(new Error('No readonly open'))
 
+// NON_BLOCKING_OPS
+var READ_OP = 0
+var WRITE_OP = 1
+var DEL_OP = 2
+var STAT_OP = 3
+
+// BLOCKING_OPS
+var OPEN_OP = 4 
+var CLOSE_OP = 5 
+var DESTROY_OP = 6
+
 module.exports = RandomAccess
 
 function RandomAccess (opts) {
@@ -42,7 +53,7 @@ function RandomAccess (opts) {
 inherits(RandomAccess, events.EventEmitter)
 
 RandomAccess.prototype.read = function (offset, size, cb) {
-  this.run(new Request(this, 0, offset, size, null, cb))
+  this.run(new Request(this, READ_OP, offset, size, null, cb))
 }
 
 RandomAccess.prototype._read = NOT_READABLE
@@ -50,7 +61,7 @@ RandomAccess.prototype._read = NOT_READABLE
 RandomAccess.prototype.write = function (offset, data, cb) {
   if (!cb) cb = noop
   openWritable(this)
-  this.run(new Request(this, 1, offset, data.length, data, cb))
+  this.run(new Request(this, WRITE_OP, offset, data.length, data, cb))
 }
 
 RandomAccess.prototype._write = NOT_WRITABLE
@@ -58,13 +69,13 @@ RandomAccess.prototype._write = NOT_WRITABLE
 RandomAccess.prototype.del = function (offset, size, cb) {
   if (!cb) cb = noop
   openWritable(this)
-  this.run(new Request(this, 2, offset, size, null, cb))
+  this.run(new Request(this, DEL_OP, offset, size, null, cb))
 }
 
 RandomAccess.prototype._del = NOT_DELETABLE
 
 RandomAccess.prototype.stat = function (cb) {
-  this.run(new Request(this, 3, 0, 0, null, cb))
+  this.run(new Request(this, STAT_OP, 0, 0, null, cb))
 }
 
 RandomAccess.prototype._stat = NOT_STATABLE
@@ -72,7 +83,7 @@ RandomAccess.prototype._stat = NOT_STATABLE
 RandomAccess.prototype.open = function (cb) {
   if (!cb) cb = noop
   if (this.opened && !this._needsOpen) return process.nextTick(cb, null)
-  queueAndRun(this, new Request(this, 4, 0, 0, null, cb))
+  queueAndRun(this, new Request(this, OPEN_OP, 0, 0, null, cb))
 }
 
 RandomAccess.prototype._open = defaultImpl(null)
@@ -81,7 +92,7 @@ RandomAccess.prototype._openReadonly = NO_OPEN_READABLE
 RandomAccess.prototype.close = function (cb) {
   if (!cb) cb = noop
   if (this.closed) return process.nextTick(cb, null)
-  queueAndRun(this, new Request(this, 5, 0, 0, null, cb))
+  queueAndRun(this, new Request(this, CLOSE_OP, 0, 0, null, cb))
 }
 
 RandomAccess.prototype._close = defaultImpl(null)
@@ -89,7 +100,7 @@ RandomAccess.prototype._close = defaultImpl(null)
 RandomAccess.prototype.destroy = function (cb) {
   if (!cb) cb = noop
   if (!this.closed) this.close(noop)
-  queueAndRun(this, new Request(this, 6, 0, 0, null, cb))
+  queueAndRun(this, new Request(this, DESTROY_OP, 0, 0, null, cb))
 }
 
 RandomAccess.prototype._destroy = defaultImpl(null)
@@ -115,7 +126,7 @@ function Request (self, type, offset, size, data, cb) {
 }
 
 Request.prototype._maybeOpenError = function (err) {
-  if (this.type !== 4) return
+  if (this.type !== OPEN_OP) return
   var queued = this.storage._queued
   for (var i = 0; i < queued.length; i++) queued[i]._openError = err
 }
@@ -126,21 +137,21 @@ Request.prototype._unqueue = function (err) {
 
   if (!err) {
     switch (this.type) {
-      case 4:
+      case OPEN_OP:
         if (!ra.opened) {
           ra.opened = true
           ra.emit('open')
         }
         break
 
-      case 5:
+      case CLOSE_OP:
         if (!ra.closed) {
           ra.closed = true
           ra.emit('close')
         }
         break
 
-      case 6:
+      case DESTROY_OP:
         if (!ra.destroyed) {
           ra.destroyed = true
           ra.emit('destroy')
@@ -188,32 +199,32 @@ Request.prototype._run = function () {
   this._sync = true
 
   switch (this.type) {
-    case 0:
+    case READ_OP:
       if (this._openAndNotClosed()) ra._read(this)
       break
 
-    case 1:
+    case WRITE_OP:
       if (this._openAndNotClosed()) ra._write(this)
       break
 
-    case 2:
+    case DEL_OP:
       if (this._openAndNotClosed()) ra._del(this)
       break
 
-    case 3:
+    case STAT_OP:
       if (this._openAndNotClosed()) ra._stat(this)
       break
 
-    case 4:
+    case OPEN_OP:
       this._open()
       break
 
-    case 5:
+    case CLOSE_OP:
       if (ra.closed || !ra.opened) nextTick(this, null)
       else ra._close(this)
       break
 
-    case 6:
+    case DESTORY_OP:
       if (ra.destroyed) nextTick(this, null)
       else ra._destroy(this)
       break


### PR DESCRIPTION
Optimize readability of the code using names for OP types instead numbers.