### PR TITLE
Replace `process.nextTick` with `queueTick`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Easily make random-access-storage instances",
   "main": "index.js",
   "dependencies": {
-    "inherits": "^2.0.3"
+    "inherits": "^2.0.3",
+    "queue-tick": "^1.0.0"
   },
   "devDependencies": {
     "standard": "^10.0.3",


### PR DESCRIPTION
As `queueTick` isn't an exact shim and only in Node.js accepts a list of arguments to pass to the callback, I had to instead close over the arguments.